### PR TITLE
option to show HUD when OP Overlay is open

### DIFF
--- a/src/HUDPicker.as
+++ b/src/HUDPicker.as
@@ -146,7 +146,7 @@ void OnDestroyed() {
     SetVis(-1);
 }
 
-bool prev_isOverlayShown = false;
+bool first_hidden = true;
 
 void Main() {
     @gameInfo = GameInfo();
@@ -177,10 +177,14 @@ void Main() {
                 OnEnabled();
             }
         }
-        if (gameInfo.IsPlaying()) {
+        if (gameInfo.IsPlaying() && (!toggleInterface || !UI::IsOverlayShown()) ) {
+            int hidden = first_hidden ? 1 : 0;
+            first_hidden = false;
             IterateSection("Race", 0);
             IterateSection("Knockout", 0);
         } else {
+            if (!first_hidden) OnDisabled();
+            first_hidden = true;
             ResetIndexes("Race");
             ResetIndexes("Knockout");
         }

--- a/src/HUDPicker.as
+++ b/src/HUDPicker.as
@@ -146,10 +146,12 @@ void OnDestroyed() {
     SetVis(-1);
 }
 
+bool prev_isOverlayShown = false;
+
 void Main() {
     @gameInfo = GameInfo();
 
-    // Initial settings load 
+    // Initial settings load
     auto curSettings = Json::FromFile(IO::FromStorageFolder("settings.json"));
     if (curSettings.GetType() == Json::Type::Null) {
         uiDic = Json::Parse(elementsJson);
@@ -166,6 +168,14 @@ void Main() {
         // wait until playground finishes loading
         while (gameInfo.LoadProgress.State == NGameLoadProgress_SMgr::EState::Displayed) {
             yield();
+        }
+        if (toggleInterface && UI::IsOverlayShown() != prev_isOverlayShown) {
+            prev_isOverlayShown = UI::IsOverlayShown();
+            if (prev_isOverlayShown) {
+                OnDisabled();
+            } else {
+                OnEnabled();
+            }
         }
         if (gameInfo.IsPlaying()) {
             IterateSection("Race", 0);

--- a/src/Settings.as
+++ b/src/Settings.as
@@ -1,7 +1,11 @@
 bool resetSwitch = false;
 
+[Setting hidden]
+bool toggleInterface = false;
+
 [SettingsTab name="HUD Tree" icon="Kenney::Car"]
 void RenderHUDTreeSettings() {
+    toggleInterface = UI::Checkbox("Show HUD when Openplanet Interface is shown", toggleInterface);
     UI::TextWrapped("DISCLAIMER: You are responsible for ensuring you re-enable any hidden elements. Otherwise disabling the plugin should re-enable all elements");
     if (gameInfo.IsPlaying()) {
         if (UI::TreeNode("Race", UI::TreeNodeFlags::Framed)) {


### PR DESCRIPTION
Adds  the option to only hide the Interface when the OpenPlanet overlay is off. I basically use this to replace/enhance the in-game interface toggle.